### PR TITLE
Fix copy_wget to cope with queries embedded in the source URL

### DIFF
--- a/script_actions.rb
+++ b/script_actions.rb
@@ -137,10 +137,14 @@ fi
 
 copy_wget() {
 echo "wget: $2 <= $1"
-f=$(basename $2)
-d=$(dirname $2)
-cd $d
-#{wget_update('$1', '$f')}
+f1=$(basename $1)
+d1=$(dirname $1)
+f2=$(basename $2)
+d2=$(dirname $2)
+cd $d2
+#{wget_update('$1', '$f2')}
+#{comment("wget has no true equivalent of curl's -o option.")}
+if [ "$f1" != "$f2" ]; then mv $f1 $f2; fi
 cd -
 }
 eos


### PR DESCRIPTION
It does this by removing the query.  There doesn't seem to be any
better alternative.  (Why are queries being added anyway?  I don't
see them on TeamCity.)

Note that wget treating queries as part of the filename totally breaks
building Bloom for Linux on Jenkins.  (or on local machines that don't
have curl)