### PR TITLE
Fix copy_wget for differing versions of wget

### DIFF
--- a/script_actions.rb
+++ b/script_actions.rb
@@ -138,13 +138,13 @@ fi
 copy_wget() {
 echo "wget: $2 <= $1"
 f1=$(basename $1)
-d1=$(dirname $1)
 f2=$(basename $2)
-d2=$(dirname $2)
-cd $d2
+cd $(dirname $2)
 #{wget_update('$1', '$f2')}
 #{comment("wget has no true equivalent of curl's -o option.")}
-if [ "$f1" != "$f2" ]; then mv $f1 $f2; fi
+#{comment("Different versions of wget handle (or not) % escaping differently.")}
+#{comment("A URL query is the only reason why $f1 and $f2 should differ.")}
+if [ "$f1" != "$f2" ]; then mv $f2\\?* $f2; fi
 cd -
 }
 eos


### PR DESCRIPTION
wget 1.13 translates %3C to < in creating filenames, wget 1.15 does not.
So we change to using wildcard matching in the renaming.  The only
restriction is that the bad name must be due to a query (starts with ?).