### PR TITLE
Update Gems to work with Ruby 2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,37 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    awesome_print (1.2.0)
-    mime-types (2.0)
-    mini_portile (0.5.2)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
-    nokogiri (1.6.0-x86-mingw32)
-      mini_portile (~> 0.5.0)
+    awesome_print (1.7.0)
+    domain_name (0.5.20161021)
+      unf (>= 0.0.5, < 1.0.0)
+    ffi (1.9.14-x86-mingw32)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
+    netrc (0.11.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    nokogiri (1.6.8.1-x86-mingw32)
+      mini_portile2 (~> 2.1.0)
     nokogiri-pretty (0.1.0)
       nokogiri
-    nori (2.3.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    nori (2.6.0)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rest-client (2.0.0-x86-mingw32)
+      ffi (~> 1.9)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.2-x86-mingw32)
 
 PLATFORMS
   ruby
@@ -24,3 +43,6 @@ DEPENDENCIES
   nokogiri-pretty
   nori
   rest-client
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
Ubuntu 16.04 Xenial doesn't have Ruby 1.9x. Updating the
Gems to the newer versions in this patch seems to make
things work.

I haven't tested this on Windows nor on Trusty and I don't have much experience with Gems so this change might be total crap, but at least it works on my machine :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrisvire/buildupdate/17)
<!-- Reviewable:end -->
