### PR TITLE
Fix excluding of files

### DIFF
--- a/team_city.rb
+++ b/team_city.rb
@@ -33,6 +33,7 @@ class ArtifactDependency
           value.split("\n").each do |line|
             if line =~ /^[+\-]:/
               (op,pattern) = line.split(':')
+              pattern = pattern.delete("\n").delete("\r")
               @exclusion_rules[pattern] = op
             else
               (src,dst) = line.split('=>')


### PR DESCRIPTION
Previously exclusions didn't work unless they happened to
be the last line of the file. We now strip line ending
characters from the pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrisvire/buildupdate/18)
<!-- Reviewable:end -->
