### PR TITLE
Update to use https instead of http for generated scripts (20220208)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     mime-types (2.0)
     mini_portile2 (2.3.0)
     netrc (0.11.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     nokogiri (1.8.2-x64-mingw32)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.2-x86-mingw32)
@@ -19,6 +21,10 @@ GEM
     nokogiri-pretty (0.1.0)
       nokogiri
     nori (2.6.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rest-client (2.0.2-x64-mingw32)
       ffi (~> 1.9)
       http-cookie (>= 1.0.2, < 2.0)
@@ -31,10 +37,12 @@ GEM
       netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
+    unf_ext (0.0.7.5)
     unf_ext (0.0.7.5-x64-mingw32)
     unf_ext (0.0.7.5-x86-mingw32)
 
 PLATFORMS
+  ruby
   x64-mingw32
   x86-mingw32
 

--- a/buildupdate.rb
+++ b/buildupdate.rb
@@ -150,9 +150,9 @@ verbose("Options: #{$options}")
 server = $options[:server]
 $username = ENV["BUILDUPDATE_USER"] || ask("Enter #{server} username: ") { |q| q.echo = true }
 $password = ENV["BUILDUPDATE_PASSWORD"] || ask("Enter #{server} password: ") { |q| q.echo = "*" }
-rest_url = "http://#{server}/httpAuth/app/rest/10.0"
+rest_url = "https://#{server}/httpAuth/app/rest/10.0"
 rest_api = RestClient::Resource.new(rest_url, :user=>$username, :password => $password) #, :headers => { :accept => "application/json"})
-repo_url = "http://#{server}/guestAuth/repository"
+repo_url = "https://#{server}/guestAuth/repository"
 repo_api = RestClient::Resource.new(repo_url)
 
 if $options[:build_type].nil?


### PR DESCRIPTION
The lock file automatically updated itself.  I assume it would do the
same for others, so included it.